### PR TITLE
Lower output "size" variables.

### DIFF
--- a/src/libresplit.rs
+++ b/src/libresplit.rs
@@ -30,9 +30,10 @@ impl LibreSplitFile {
             splits.push(split);
         }
 
-        // Get size. Default for now.
-        let width = 600;
-        let height = 800;
+        // Get size.
+        // The window of LibreSplit will not shrink beyond this size.
+        let width = 60;
+        let height = 80;
 
         LibreSplitFile {
             title,


### PR DESCRIPTION
When loading splits made by the converter, LibreSplit will not shrink it's window below the size given in the output split file.

Reducing the default size is only the first step. Eventually a size should be able to be selected on libresplit.org when converting split files.